### PR TITLE
Add special recipient "nobody" to not send report

### DIFF
--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -109,7 +109,9 @@ def lambda_handler(event, context):
     print("*********************************************************************")
 
     # if sendto: is in args then send jarvis message to slack channel in args
-    if sendto_data:
+    if sendto_data == "nobody":
+        print('Not sending report')
+    elif sendto_data:
         send_to_slack(retval, sendto_data[0], param_map['user_name'])
     else:
         post_to_slack(retval)


### PR DESCRIPTION
Previously, executions for seeding the report cache have always been "failed" Lambda invocations because the response_url was set to localhost and an exception would get thrown. This PR should allow "sendto nobody" to skip sending a report and allow the execution to be reported as successful